### PR TITLE
Support for Bootstrap v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,13 @@ cache:
 matrix:
   include:
     - php: 7.4
-      env: LARAVEL='7.*' TESTBENCH='5.*' COMPOSER_FLAGS='--prefer-lowest'
+      env: LARAVEL='7.*' TESTBENCH='5.*' COMPOSER_FLAGS='--prefer-lowest' FORM_COMPONENTS_FRAMEWORK='tailwind'
     - php: 7.4
-      env: LARAVEL='7.*' TESTBENCH='5.*' COMPOSER_FLAGS='--prefer-stable'
+      env: LARAVEL='7.*' TESTBENCH='5.*' COMPOSER_FLAGS='--prefer-stable'FORM_COMPONENTS_FRAMEWORK='tailwind'
+    - php: 7.4
+      env: LARAVEL='7.*' TESTBENCH='5.*' COMPOSER_FLAGS='--prefer-lowest'FORM_COMPONENTS_FRAMEWORK='bootstrap-4'
+    - php: 7.4
+      env: LARAVEL='7.*' TESTBENCH='5.*' COMPOSER_FLAGS='--prefer-stable'FORM_COMPONENTS_FRAMEWORK='bootstrap-4'
   fast_finish: true
 
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-form-components` will be documented in this file
 
+## 1.1.0 - 2020-07-18
+
+- added support for Bootstrap 4
+
 ## 1.0.1 - 2020-07-18
 
 - added `hasErrorAndShow` method to components

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ A set of Blade components to build forms with [Tailwind CSS Custom Forms](https:
 
 ## Features
 
-* Components for input, textarea, select, multi-select, checkbox and radio elements
-* Support for [Tailwind CSS Custom Forms](https://tailwindcss-custom-forms.netlify.app)
-* Bind a target to a form (or a set of elements) to provide default values
-* Support for Spatie's [laravel-translatable](https://github.com/spatie/laravel-translatable)
-* Re-populate forms with [old input](https://laravel.com/docs/master/requests#old-input)
-* Validation errors
-* Components classes and Blade views fully customizable
-* Support for prefixing the components
-* Prepared for other CSS frameworks as well (in a future release)
+* Components for input, textarea, select, multi-select, checkbox and radio elements.
+* Support for [Tailwind CSS Custom Forms](https://tailwindcss-custom-forms.netlify.app) and [Bootstrap 4 Forms](https://getbootstrap.com/docs/4.0/components/forms/).
+* Bind a target to a form (or a set of elements) to provide default values.
+* Support for Spatie's [laravel-translatable](https://github.com/spatie/laravel-translatable).
+* Re-populate forms with [old input](https://laravel.com/docs/master/requests#old-input).
+* Validation errors.
+* Components classes and Blade views fully customizable.
+* Support for prefixing the components.
+* Component logic independent from Blade views, the Tailwind and Bootstrap views use the same logic.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,6 @@ You can bind your own component classes to any of the elements. In the `form-com
 You can define a prefix in the `form-components.php` configuration file.
 
 ```php
-
 return [
     'prefix' => 'tailwind',
 ];
@@ -275,6 +274,50 @@ By the default, the errors messages are positioned under the element. To show th
 
     <x-form-errors name="company_name" />
 </x-form>
+```
+
+### Submit button
+
+The label defaults to *Submit* but you can use the slot to provide your own content.
+
+```blade
+<x-form-submit>
+    <span class="text-green-500">Send</span>
+</x-form-submit>
+```
+
+### Bootstrap 4
+
+You can switch to [Bootstrap 4](https://getbootstrap.com/docs/4.0/components/forms/) by change the `framework` in the `form-components.php` configuration file.
+
+```php
+return [
+    'framework' => 'bootstrap-4',
+];
+```
+
+There is a little bit of styling added to the `form.blade.php` view to add support for inline form groups. If you want to change or remove it, [publish the assets](#customize-the-blade-views) and update the view file.
+
+#### Input prepend
+
+```blade
+<x-form-input name="username" label="Username">
+    @slot('prepend')
+        <span>@</span>
+    @endslot
+</x-form-input>
+```
+
+#### Help text
+
+```blade
+<x-form-input name="username" label="Username">
+    @slot('help')
+        <small class="form-text text-muted">
+            Your username must be 8-20 characters long
+        </small>
+    @endslot
+</x-form-input>
 ```
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ The label defaults to *Submit* but you can use the slot to provide your own cont
 
 ### Bootstrap 4
 
-You can switch to [Bootstrap 4](https://getbootstrap.com/docs/4.0/components/forms/) by change the `framework` in the `form-components.php` configuration file.
+You can switch to [Bootstrap 4](https://getbootstrap.com/docs/4.0/components/forms/) by updating the `framework` in the `form-components.php` configuration file.
 
 ```php
 return [
@@ -296,9 +296,11 @@ return [
 ];
 ```
 
-There is a little bit of styling added to the `form.blade.php` view to add support for inline form groups. If you want to change or remove it, [publish the assets](#customize-the-blade-views) and update the view file.
+There is a little bit of styling added to the `form.blade.php` view to add support for inline form groups. If you want to change it or remove it, [publish the assets](#customize-the-blade-views) and update the view file.
 
-#### Input prepend
+#### Input prepend and append
+
+In addition to the Tailwind features, there is also support for [input groups](https://getbootstrap.com/docs/4.1/components/forms/#auto-sizing). Use the `prepend` and `append` slots to provide the contents.
 
 ```blade
 <x-form-input name="username" label="Username">
@@ -306,7 +308,15 @@ There is a little bit of styling added to the `form.blade.php` view to add suppo
         <span>@</span>
     @endslot
 </x-form-input>
+
+<x-form-input name="subdomain" label="Subdomain">
+    @slot('append')
+        <span>.protone.media</span>
+    @endslot
+</x-form-input>
 ```
+
+You can add [block-level help text](https://getbootstrap.com/docs/4.1/components/forms/#help-text) to any element by using the `help` slot.
 
 #### Help text
 
@@ -314,7 +324,7 @@ There is a little bit of styling added to the `form.blade.php` view to add suppo
 <x-form-input name="username" label="Username">
     @slot('help')
         <small class="form-text text-muted">
-            Your username must be 8-20 characters long
+            Your username must be 8-20 characters long.
         </small>
     @endslot
 </x-form-input>

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ By default every element shows validation errors but you can hide them if you wa
 <x-form-textarea name="description" :show-errors="false" />
 ```
 
-### Default value
+### Default value and binds
 
 You can use the `default` attribute to specify the default value of the element.
 
@@ -106,7 +106,7 @@ You can use the `default` attribute to specify the default value of the element.
 <x-form-textarea name="motivation" default="I want to use this package because..." />
 ```
 
-### Binding a target
+#### Binding a target
 
 Instead of setting a default value, you can also pass in a target, like an Eloquent model. Now the component will get the value from the target by the `name`.
 
@@ -116,7 +116,7 @@ Instead of setting a default value, you can also pass in a target, like an Eloqu
 
 In the example above, where `$video` is an Eloquent model, the default value will be `$video->description`.
 
-### Binding a target to multiple elements
+#### Binding a target to multiple elements
 
 You can also bind a target by using the `@bind` directive. This will bind the target to all elements until the `@endbind` directive.
 
@@ -145,7 +145,7 @@ You can even mix targets!
 </x-form>
 ```
 
-### Override or remove a binding
+#### Override or remove a binding
 
 You can override the `@bind` directive by passing a target directly to the element using the `:bind` attribute. If you want to remove a binding for a specific element, pass in `false`.
 
@@ -240,7 +240,7 @@ php artisan vendor:publish --provider="ProtoneMedia\LaravelFormComponents\Suppor
 
 You can find the Blade views in the `resources/views/vendor/form-components` folder. Optionally, in the `form-components.php` configuration file, you can change the location of the Blade view *per* component.
 
-### Customize the components
+#### Component logic
 
 You can bind your own component classes to any of the elements. In the `form-components.php` configuration file, you can change the class *per* component. As the logic for the components is quite complex, it is strongly recommended to duplicate the default component as a starting point and start editing. You'll find the default component classes in the `vendor/protonemedia/laravel-form-components/src/Components` folder.
 
@@ -316,9 +316,9 @@ In addition to the Tailwind features, there is also support for [input groups](h
 </x-form-input>
 ```
 
-You can add [block-level help text](https://getbootstrap.com/docs/4.1/components/forms/#help-text) to any element by using the `help` slot.
-
 #### Help text
+
+You can add [block-level help text](https://getbootstrap.com/docs/4.1/components/forms/#help-text) to any element by using the `help` slot.
 
 ```blade
 <x-form-input name="username" label="Username">

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ The label defaults to *Submit* but you can use the slot to provide your own cont
 
 ### Bootstrap 4
 
-You can switch to [Bootstrap 4](https://getbootstrap.com/docs/4.0/components/forms/) by updating the `framework` in the `form-components.php` configuration file.
+You can switch to [Bootstrap 4](https://getbootstrap.com/docs/4.0/components/forms/) by updating the `framework` setting in the `form-components.php` configuration file.
 
 ```php
 return [

--- a/resources/views/bootstrap-4/form-checkbox.blade.php
+++ b/resources/views/bootstrap-4/form-checkbox.blade.php
@@ -11,6 +11,8 @@
 
     <x-form-label :label="$label" :for="$name" class="form-check-label" />
 
+    {!! $help ?? null !!}
+
     @if($hasErrorAndShow($name))
         <x-form-errors :name="$name" />
     @endif

--- a/resources/views/bootstrap-4/form-checkbox.blade.php
+++ b/resources/views/bootstrap-4/form-checkbox.blade.php
@@ -1,19 +1,17 @@
-<div class="form-group">
-    <div class="form-check">
-        <input {!! $attributes->merge(['class' => 'form-check-input']) !!}
-            type="checkbox"
-            name="{{ $name }}"
-            value="{{ $value }}"
+<div class="form-check">
+    <input {!! $attributes->merge(['class' => 'form-check-input ' . ($hasError($name) ? 'is-invalid' : '')]) !!}
+        type="checkbox"
+        name="{{ $name }}"
+        value="{{ $value }}"
 
-            @if($checked)
-                checked="checked"
-            @endif
-        />
-
-        <x-form-label :label="$label" :for="$name" class="form-check-label" />
-
-        @if($showErrors)
-            <x-form-errors :name="$name" />
+        @if($checked)
+            checked="checked"
         @endif
-    </div>
+    />
+
+    <x-form-label :label="$label" :for="$name" class="form-check-label" />
+
+    @if($hasErrorAndShow($name))
+        <x-form-errors :name="$name" />
+    @endif
 </div>

--- a/resources/views/bootstrap-4/form-checkbox.blade.php
+++ b/resources/views/bootstrap-4/form-checkbox.blade.php
@@ -1,0 +1,19 @@
+<div class="form-group">
+    <div class="form-check">
+        <input {!! $attributes->merge(['class' => 'form-check-input']) !!}
+            type="checkbox"
+            name="{{ $name }}"
+            value="{{ $value }}"
+
+            @if($checked)
+                checked="checked"
+            @endif
+        />
+
+        <x-form-label :label="$label" :for="$name" class="form-check-label" />
+
+        @if($showErrors)
+            <x-form-errors :name="$name" />
+        @endif
+    </div>
+</div>

--- a/resources/views/bootstrap-4/form-errors.blade.php
+++ b/resources/views/bootstrap-4/form-errors.blade.php
@@ -1,0 +1,7 @@
+@if($name)
+    @error($name)
+        <div {!! $attributes->merge(['class' => 'invalid-feedback']) !!}>
+            {{ $message }}
+        </div>
+    @enderror
+@endif

--- a/resources/views/bootstrap-4/form-errors.blade.php
+++ b/resources/views/bootstrap-4/form-errors.blade.php
@@ -1,7 +1,5 @@
-@if($name)
-    @error($name)
-        <div {!! $attributes->merge(['class' => 'invalid-feedback']) !!}>
-            {{ $message }}
-        </div>
-    @enderror
-@endif
+@error($name)
+    <div {!! $attributes->merge(['class' => 'invalid-feedback']) !!}>
+        {{ $message }}
+    </div>
+@enderror

--- a/resources/views/bootstrap-4/form-group.blade.php
+++ b/resources/views/bootstrap-4/form-group.blade.php
@@ -1,11 +1,11 @@
-<div class="mt-4">
+<div {!! $attributes->merge(['class' => 'form-group '  . ($hasError($name) ? 'is-invalid' : '')]) !!}>
     <x-form-label :label="$label" />
 
-    <div class="@if($label) mt-2 @endif @if($inline) flex flex-wrap space-x-6 @endif">
+    <div class="@if($inline) d-flex flex-row flex-wrap inline-space @endif">
         {!! $slot !!}
     </div>
 
-    @if($showErrors)
-        <x-form-errors :name="$name" />
+    @if($hasErrorAndShow($name))
+        <x-form-errors :name="$name" class="d-block" />
     @endif
 </div>

--- a/resources/views/bootstrap-4/form-group.blade.php
+++ b/resources/views/bootstrap-4/form-group.blade.php
@@ -1,0 +1,11 @@
+<div class="mt-4">
+    <x-form-label :label="$label" />
+
+    <div class="@if($label) mt-2 @endif @if($inline) flex flex-wrap space-x-6 @endif">
+        {!! $slot !!}
+    </div>
+
+    @if($showErrors)
+        <x-form-errors :name="$name" />
+    @endif
+</div>

--- a/resources/views/bootstrap-4/form-group.blade.php
+++ b/resources/views/bootstrap-4/form-group.blade.php
@@ -5,6 +5,8 @@
         {!! $slot !!}
     </div>
 
+    {!! $help ?? null !!}
+
     @if($hasErrorAndShow($name))
         <x-form-errors :name="$name" class="d-block" />
     @endif

--- a/resources/views/bootstrap-4/form-input.blade.php
+++ b/resources/views/bootstrap-4/form-input.blade.php
@@ -1,11 +1,23 @@
 <div class="form-group">
     <x-form-label :label="$label" :for="$name" />
 
-    <input {!! $attributes->merge(['class' => 'form-control ' . ($hasError($name) ? 'is-invalid' : '')]) !!}
-        name="{{ $name }}"
-        type="{{ $type }}"
-        value="{{ $value }}"
-    />
+    <div class="input-group">
+        @isset($prepend)
+            <div class="input-group-prepend">
+                <div class="input-group-text">
+                    {!! $prepend !!}
+                </div>
+            </div>
+        @endisset
+
+        <input {!! $attributes->merge(['class' => 'form-control ' . ($hasError($name) ? 'is-invalid' : '')]) !!}
+            name="{{ $name }}"
+            type="{{ $type }}"
+            value="{{ $value }}"
+        />
+    </div>
+
+    {!! $help ?? null !!}
 
     @if($hasErrorAndShow($name))
         <x-form-errors :name="$name" />

--- a/resources/views/bootstrap-4/form-input.blade.php
+++ b/resources/views/bootstrap-4/form-input.blade.php
@@ -1,0 +1,13 @@
+<div class="form-group">
+    <x-form-label :label="$label" :for="$name" />
+
+    <input {!! $attributes->merge(['class' => 'form-control']) !!}
+        name="{{ $name }}"
+        type="{{ $type }}"
+        value="{{ $value }}"
+    />
+
+    @if($showErrors)
+        <x-form-errors :name="$name" />
+    @endif
+</div>

--- a/resources/views/bootstrap-4/form-input.blade.php
+++ b/resources/views/bootstrap-4/form-input.blade.php
@@ -1,13 +1,13 @@
 <div class="form-group">
     <x-form-label :label="$label" :for="$name" />
 
-    <input {!! $attributes->merge(['class' => 'form-control']) !!}
+    <input {!! $attributes->merge(['class' => 'form-control ' . ($hasError($name) ? 'is-invalid' : '')]) !!}
         name="{{ $name }}"
         type="{{ $type }}"
         value="{{ $value }}"
     />
 
-    @if($showErrors)
+    @if($hasErrorAndShow($name))
         <x-form-errors :name="$name" />
     @endif
 </div>

--- a/resources/views/bootstrap-4/form-input.blade.php
+++ b/resources/views/bootstrap-4/form-input.blade.php
@@ -15,6 +15,14 @@
             type="{{ $type }}"
             value="{{ $value }}"
         />
+
+        @isset($append)
+            <div class="input-group-append">
+                <div class="input-group-text">
+                    {!! $append !!}
+                </div>
+            </div>
+        @endisset
     </div>
 
     {!! $help ?? null !!}

--- a/resources/views/bootstrap-4/form-label.blade.php
+++ b/resources/views/bootstrap-4/form-label.blade.php
@@ -1,0 +1,3 @@
+@if($label)
+    <label {!! $attributes !!}>{{ $label }}</label>
+@endif

--- a/resources/views/bootstrap-4/form-radio.blade.php
+++ b/resources/views/bootstrap-4/form-radio.blade.php
@@ -1,0 +1,19 @@
+<div>
+    <label class="inline-flex items-center">
+        <input {!! $attributes->merge(['class' => 'form-radio']) !!}
+            type="radio"
+            name="{{ $name }}"
+            value="{{ $value }}"
+
+            @if($checked)
+                checked="checked"
+            @endif
+        />
+
+        <span class="ml-2">{{ $label }}</span>
+    </label>
+
+    @if($showErrors)
+        <x-form-errors :name="$name" />
+    @endif
+</div>

--- a/resources/views/bootstrap-4/form-radio.blade.php
+++ b/resources/views/bootstrap-4/form-radio.blade.php
@@ -11,6 +11,8 @@
 
    <x-form-label :label="$label" :for="$name" class="form-check-label" />
 
+    {!! $help ?? null !!}
+
     @if($hasErrorAndShow($name))
         <x-form-errors :name="$name" />
     @endif

--- a/resources/views/bootstrap-4/form-radio.blade.php
+++ b/resources/views/bootstrap-4/form-radio.blade.php
@@ -1,19 +1,17 @@
-<div>
-    <label class="inline-flex items-center">
-        <input {!! $attributes->merge(['class' => 'form-radio']) !!}
-            type="radio"
-            name="{{ $name }}"
-            value="{{ $value }}"
+<div class="form-check">
+    <input {!! $attributes->merge(['class' => 'form-check-input ' . ($hasError($name) ? 'is-invalid' : '')]) !!}
+        type="radio"
+        name="{{ $name }}"
+        value="{{ $value }}"
 
-            @if($checked)
-                checked="checked"
-            @endif
-        />
+        @if($checked)
+            checked="checked"
+        @endif
+    />
 
-        <span class="ml-2">{{ $label }}</span>
-    </label>
+   <x-form-label :label="$label" :for="$name" class="form-check-label" />
 
-    @if($showErrors)
+    @if($hasErrorAndShow($name))
         <x-form-errors :name="$name" />
     @endif
 </div>

--- a/resources/views/bootstrap-4/form-select.blade.php
+++ b/resources/views/bootstrap-4/form-select.blade.php
@@ -14,6 +14,8 @@
         @endforeach
     </select>
 
+    {!! $help ?? null !!}
+
     @if($hasErrorAndShow($name))
         <x-form-errors :name="$name" />
     @endif

--- a/resources/views/bootstrap-4/form-select.blade.php
+++ b/resources/views/bootstrap-4/form-select.blade.php
@@ -1,0 +1,24 @@
+<div class="mt-4">
+    <label class="block">
+        <x-form-label :label="$label" />
+
+        <select name="{{ $name }}"
+            @if($multiple)
+                multiple
+            @endif
+
+            {!! $attributes->merge([
+                'class' => ($label ? 'mt-1' : '') . ' block w-full ' . ($multiple ? 'form-multiselect' : 'form-select')
+            ]) !!}>
+            @foreach($options as $key => $option)
+                <option value="{{ $key }}" @if($isSelected($key)) selected="selected" @endif>
+                    {{ $option }}
+                </option>
+            @endforeach
+        </select>
+    </label>
+
+    @if($showErrors)
+        <x-form-errors :name="$name" />
+    @endif
+</div>

--- a/resources/views/bootstrap-4/form-select.blade.php
+++ b/resources/views/bootstrap-4/form-select.blade.php
@@ -1,24 +1,20 @@
-<div class="mt-4">
-    <label class="block">
-        <x-form-label :label="$label" />
+<div class="form-group">
+    <x-form-label :label="$label" :for="$name" />
 
-        <select name="{{ $name }}"
-            @if($multiple)
-                multiple
-            @endif
+    <select name="{{ $name }}"
+        @if($multiple)
+            multiple
+        @endif
 
-            {!! $attributes->merge([
-                'class' => ($label ? 'mt-1' : '') . ' block w-full ' . ($multiple ? 'form-multiselect' : 'form-select')
-            ]) !!}>
-            @foreach($options as $key => $option)
-                <option value="{{ $key }}" @if($isSelected($key)) selected="selected" @endif>
-                    {{ $option }}
-                </option>
-            @endforeach
-        </select>
-    </label>
+        {!! $attributes->merge(['class' => 'form-control ' . ($hasError($name) ? 'is-invalid' : '')]) !!}>
+        @foreach($options as $key => $option)
+            <option value="{{ $key }}" @if($isSelected($key)) selected="selected" @endif>
+                {{ $option }}
+            </option>
+        @endforeach
+    </select>
 
-    @if($showErrors)
+    @if($hasErrorAndShow($name))
         <x-form-errors :name="$name" />
     @endif
 </div>

--- a/resources/views/bootstrap-4/form-submit.blade.php
+++ b/resources/views/bootstrap-4/form-submit.blade.php
@@ -1,5 +1,6 @@
-<div class="mt-6 flex items-center justify-between">
-    <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" type="submit">
-        {{ $label }}
-    </button>
-</div>
+<button {!! $attributes->merge([
+    'class' => 'btn btn-primary',
+    'type' => 'submit'
+]) !!}>
+    {!! trim($slot) ?: __('Submit') !!}
+</button>

--- a/resources/views/bootstrap-4/form-submit.blade.php
+++ b/resources/views/bootstrap-4/form-submit.blade.php
@@ -1,0 +1,5 @@
+<div class="mt-6 flex items-center justify-between">
+    <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" type="submit">
+        {{ $label }}
+    </button>
+</div>

--- a/resources/views/bootstrap-4/form-textarea.blade.php
+++ b/resources/views/bootstrap-4/form-textarea.blade.php
@@ -1,14 +1,10 @@
-<div class="mt-4">
-    <label class="block">
-        <x-form-label :label="$label" />
+<div class="form-group">
+    <x-form-label :label="$label" :for="$name" />
 
-        <textarea {!! $attributes->merge([
-            'class' => 'form-textarea block w-full ' . ($label ? 'mt-1' : '')
-        ]) !!}
-            name="{{ $name }}">{!! $value !!}</textarea>
-    </label>
+    <textarea {!! $attributes->merge(['class' => 'form-control ' . ($hasError($name) ? 'is-invalid' : '')]) !!}
+        name="{{ $name }}">{!! $value !!}</textarea>
 
-    @if($showErrors)
+    @if($hasErrorAndShow($name))
         <x-form-errors :name="$name" />
     @endif
 </div>

--- a/resources/views/bootstrap-4/form-textarea.blade.php
+++ b/resources/views/bootstrap-4/form-textarea.blade.php
@@ -4,6 +4,8 @@
     <textarea {!! $attributes->merge(['class' => 'form-control ' . ($hasError($name) ? 'is-invalid' : '')]) !!}
         name="{{ $name }}">{!! $value !!}</textarea>
 
+    {!! $help ?? null !!}
+
     @if($hasErrorAndShow($name))
         <x-form-errors :name="$name" />
     @endif

--- a/resources/views/bootstrap-4/form-textarea.blade.php
+++ b/resources/views/bootstrap-4/form-textarea.blade.php
@@ -1,0 +1,14 @@
+<div class="mt-4">
+    <label class="block">
+        <x-form-label :label="$label" />
+
+        <textarea {!! $attributes->merge([
+            'class' => 'form-textarea block w-full ' . ($label ? 'mt-1' : '')
+        ]) !!}
+            name="{{ $name }}">{!! $value !!}</textarea>
+    </label>
+
+    @if($showErrors)
+        <x-form-errors :name="$name" />
+    @endif
+</div>

--- a/resources/views/bootstrap-4/form.blade.php
+++ b/resources/views/bootstrap-4/form.blade.php
@@ -1,4 +1,12 @@
-<form method="{{ $method }}" {!! $attributes !!}>
+<form method="{{ $method }}" {!! $attributes->merge([
+    'class' => $hasError() ? 'needs-validation' : ''
+]) !!}>
+    <style>
+        .inline-space > :not(template) {
+            margin-right: 1.25rem;
+        }
+    </style>
+
     @unless(in_array($method, ['HEAD', 'GET', 'OPTIONS']))
         @csrf
     @endunless

--- a/resources/views/bootstrap-4/form.blade.php
+++ b/resources/views/bootstrap-4/form.blade.php
@@ -1,0 +1,7 @@
+<form method="{{ $method }}" {!! $attributes !!}>
+    @unless(in_array($method, ['HEAD', 'GET', 'OPTIONS']))
+        @csrf
+    @endunless
+
+    {!! $slot !!}
+</form>

--- a/src/Components/Form.php
+++ b/src/Components/Form.php
@@ -2,6 +2,8 @@
 
 namespace ProtoneMedia\LaravelFormComponents\Components;
 
+use Illuminate\Support\ViewErrorBag;
+
 class Form extends Component
 {
     /**
@@ -17,5 +19,18 @@ class Form extends Component
     public function __construct(string $method = 'POST')
     {
         $this->method = strtoupper($method);
+    }
+
+    /**
+     * Returns a boolean wether the error bag is not empty.
+     *
+     * @param string $bag
+     * @return boolean
+     */
+    public function hasError($bag = 'default'): bool
+    {
+        $errors = request()->session()->get('errors') ?: new ViewErrorBag;
+
+        return $errors->getBag($bag)->isNotEmpty();
     }
 }

--- a/src/Components/FormSubmit.php
+++ b/src/Components/FormSubmit.php
@@ -4,15 +4,4 @@ namespace ProtoneMedia\LaravelFormComponents\Components;
 
 class FormSubmit extends Component
 {
-    public string $label;
-
-    /**
-     * Create a new component instance.
-     *
-     * @return void
-     */
-    public function __construct(string $label = '')
-    {
-        $this->label = $label ?: __('Submit');
-    }
 }

--- a/src/Components/HandlesDefaultAndOldValue.php
+++ b/src/Components/HandlesDefaultAndOldValue.php
@@ -20,7 +20,9 @@ trait HandlesDefaultAndOldValue
 
         $bind = $this->getBoundTarget($bind, $name);
 
-        $default = $bind->getTranslation($name, $language, false) ?: $default;
+        if ($bind) {
+            $default = $bind->getTranslation($name, $language, false) ?: $default;
+        }
 
         $this->value = old("{$name}.{$language}", $default);
     }

--- a/src/Components/HandlesValidationErrors.php
+++ b/src/Components/HandlesValidationErrors.php
@@ -2,7 +2,40 @@
 
 namespace ProtoneMedia\LaravelFormComponents\Components;
 
+use Illuminate\Support\ViewErrorBag;
+
 trait HandlesValidationErrors
 {
     public $showErrors = true;
+
+    /**
+     * Returns a boolean wether the given attribute has an error
+     * and the should be shown.
+     *
+     * @param string $name
+     * @param string $bag
+     * @return boolean
+     */
+    public function hasErrorAndShow(string $name, string $bag = 'default'): bool
+    {
+        return $this->showErrors
+            ? $this->hasError($name, $bag)
+            : false;
+    }
+
+    /**
+     * Returns a boolean wether the given attribute has an error.
+     *
+     * @param string $name
+     * @param string $bag
+     * @return boolean
+     */
+    public function hasError(string $name, string $bag = 'default'): bool
+    {
+        $errors = request()->session()->get('errors') ?: new ViewErrorBag;
+
+        $name = str_replace(['[', ']'], ['.', ''], $name);
+
+        return $errors->getBag($bag)->has($name);
+    }
 }

--- a/tests/Feature/BootstrapTest.php
+++ b/tests/Feature/BootstrapTest.php
@@ -4,7 +4,7 @@ namespace ProtoneMedia\LaravelFormComponents\Tests\Feature;
 
 use ProtoneMedia\LaravelFormComponents\Tests\TestCase;
 
-class TranslationTest extends TestCase
+class BootstrapTest extends TestCase
 {
     /** @test */
     public function it_can_append_to_an_input()

--- a/tests/Feature/BootstrapTest.php
+++ b/tests/Feature/BootstrapTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ProtoneMedia\LaravelFormComponents\Tests\Feature;
+
+use ProtoneMedia\LaravelFormComponents\Tests\TestCase;
+
+class TranslationTest extends TestCase
+{
+    /** @test */
+    public function it_can_append_to_an_input()
+    {
+        $this->registerTestRoute('bootstrap-append');
+
+        config(['form-components.framework' => 'bootstrap-4']);
+
+        $this->visit('/bootstrap-append')
+            ->seeInElement('.input-group-text', '.protone.media');
+    }
+
+    /** @test */
+    public function it_can_prepend_to_an_input()
+    {
+        $this->registerTestRoute('bootstrap-prepend');
+
+        config(['form-components.framework' => 'bootstrap-4']);
+
+        $this->visit('/bootstrap-prepend')
+            ->seeInElement('.input-group-text', 'info@');
+    }
+
+    /** @test */
+    public function it_can_add_help_text()
+    {
+        $this->registerTestRoute('bootstrap-help');
+
+        config(['form-components.framework' => 'bootstrap-4']);
+
+        $this->visit('/bootstrap-help')
+            ->seeInElement('.form-text', 'Your username must be 8-20 characters long.');
+    }
+}

--- a/tests/Feature/BootstrapTest.php
+++ b/tests/Feature/BootstrapTest.php
@@ -6,12 +6,19 @@ use ProtoneMedia\LaravelFormComponents\Tests\TestCase;
 
 class BootstrapTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if (config('form-components.framework') !== 'bootstrap-4') {
+            $this->markTestSkipped('Other framework configured');
+        }
+    }
+
     /** @test */
     public function it_can_append_to_an_input()
     {
         $this->registerTestRoute('bootstrap-append');
-
-        config(['form-components.framework' => 'bootstrap-4']);
 
         $this->visit('/bootstrap-append')
             ->seeInElement('.input-group-text', '.protone.media');
@@ -22,8 +29,6 @@ class BootstrapTest extends TestCase
     {
         $this->registerTestRoute('bootstrap-prepend');
 
-        config(['form-components.framework' => 'bootstrap-4']);
-
         $this->visit('/bootstrap-prepend')
             ->seeInElement('.input-group-text', 'info@');
     }
@@ -32,8 +37,6 @@ class BootstrapTest extends TestCase
     public function it_can_add_help_text()
     {
         $this->registerTestRoute('bootstrap-help');
-
-        config(['form-components.framework' => 'bootstrap-4']);
 
         $this->visit('/bootstrap-help')
             ->seeInElement('.form-text', 'Your username must be 8-20 characters long.');

--- a/tests/Feature/TranslationTest.php
+++ b/tests/Feature/TranslationTest.php
@@ -42,7 +42,7 @@ class TranslationTest extends TestCase
             ->press('Submit')
             ->seeElement('input[name="input[nl]"][value="hoi"]')
             ->seeElement('input[name="input[en]"][value="hey"]')
-            ->seeInElement('p', 'The input.nl must be at least 5 characters')
-            ->seeInElement('p', 'The input.en must be at least 5 characters');
+            ->seeText('The input.nl must be at least 5 characters')
+            ->seeText('The input.en must be at least 5 characters');
     }
 }

--- a/tests/Feature/ValidationTest.php
+++ b/tests/Feature/ValidationTest.php
@@ -22,11 +22,11 @@ class ValidationTest extends TestCase
 
         $this->visit('/validation-errors')
             ->press('Submit')
-            ->seeInElement('p', 'The input field is required')
-            ->seeInElement('p', 'The textarea field is required')
-            ->seeInElement('p', 'The select field is required')
-            ->seeInElement('p', 'The checkbox field is required')
-            ->seeInElement('p', 'The radio field is required');
+            ->seeText('The input field is required')
+            ->seeText('The textarea field is required')
+            ->seeText('The select field is required')
+            ->seeText('The checkbox field is required')
+            ->seeText('The radio field is required');
     }
 
     /** @test */
@@ -44,11 +44,11 @@ class ValidationTest extends TestCase
 
         $this->visit('/hidden-validation-errors')
             ->press('Submit')
-            ->dontSeeElement('p')
-            ->dontSeeElement('p')
-            ->dontSeeElement('p')
-            ->dontSeeElement('p')
-            ->dontSeeElement('p');
+            ->dontSeeText('The input field is required')
+            ->dontSeeText('The textarea field is required')
+            ->dontSeeText('The select field is required')
+            ->dontSeeText('The checkbox field is required')
+            ->dontSeeText('The radio field is required');
     }
 
     /** @test */

--- a/tests/Feature/views/bootstrap-append.blade.php
+++ b/tests/Feature/views/bootstrap-append.blade.php
@@ -1,0 +1,7 @@
+<x-form>
+    <x-form-input name="input">
+        @slot('append')
+            .protone.media
+        @endslot
+    </x-form-input>
+</x-form>

--- a/tests/Feature/views/bootstrap-help.blade.php
+++ b/tests/Feature/views/bootstrap-help.blade.php
@@ -1,0 +1,9 @@
+<x-form>
+    <x-form-input name="input">
+        @slot('help')
+            <small class="form-text text-muted">
+                Your username must be 8-20 characters long.
+            </small>
+        @endslot
+    </x-form-input>
+</x-form>

--- a/tests/Feature/views/bootstrap-prepend.blade.php
+++ b/tests/Feature/views/bootstrap-prepend.blade.php
@@ -1,0 +1,7 @@
+<x-form>
+    <x-form-input name="input">
+        @slot('prepend')
+            info@
+        @endslot
+    </x-form-input>
+</x-form>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,6 +17,8 @@ abstract class TestCase extends BaseTestCase
 
         $this->app['config']->set('app.key', 'base64:yWa/ByhLC/GUvfToOuaPD7zDwB64qkc/QkaQOrT5IpE=');
 
+        $this->app['config']->set('form-components.framework', env('FORM_COMPONENTS_FRAMEWORK', 'tailwind'));
+
         View::addLocation(__DIR__ . '/Feature/views');
     }
 


### PR DESCRIPTION
This PR adds support for [Bootstrap 4 forms](https://getbootstrap.com/docs/4.1/components/forms/). You can switch by updating the `framework` setting in the `form-components.php` configuration file.

```php
return [
    'framework' => 'bootstrap-4',
];
```

In additional to all Tailwind features, it also supports input-groups (prepend/append) and help text.